### PR TITLE
Repairing prism-related links.

### DIFF
--- a/english.html
+++ b/english.html
@@ -73,7 +73,7 @@
 			<p style="text-align:right;font-size:12px">Made by <a href="http://www.opendatacity.de/">OpenDataCity</a>. <a rel="license" href="http://creativecommons.org/licenses/by/3.0/de/">CC-BY 3.0</a>.</p>
 			
 			<div class="alert alert-info" style="text-align: center">				
-				<a href="https://opendatacity.github.io/stasi-vs-nsa/prism/en" style="color:#08c !important"><b>Also:</b> We are showing here how our data is crossing borders during browsing the web from Germany.</a>
+				<a href="https://opendatacity.github.io/prism/" style="color:#08c !important"><b>Also:</b> We are showing here how our data is crossing borders during browsing the web from Germany.</a>
 			</div>
 
 			<div class="row-fluid" style="margin-top:50px">

--- a/francais.html
+++ b/francais.html
@@ -72,11 +72,9 @@
 			<iframe src="frame_fr.html" width="950" height="580" scrolling="no" frameborder="0"><a href="">Quelle place prendraient les armoires d’archivage de la Stasi et de la NSA – si la NSA décidait d’imprimer ses 5 zettaoctets de fichiers?</a></iframe>
 			<p style="text-align:right;font-size:12px">Réalisé par <a href="https://www.opendatacity.de/">OpenDataCity</a>. Application sous <a rel="license" href="http://creativecommons.org/licenses/by/3.0/de/">CC-BY 3.0</a>.</p>
 			
-			<!--
 			<div class="alert alert-info" style="text-align: center">				
-				<a href="http://apps.opendatacity.de/prism/" style="color:#08c !important"><b>Außerdem:</b> Wie beim Surfen unsere Daten über das Ausland geleitet werden, zeigen wir hier.</a>
+				<a href="https://opendatacity.github.io/prism/index.fr.html" style="color:#08c !important"><b>Außerdem:</b> Nous montrons ici comment nos données sont transférées à l'étranger lorsque nous surfons.</a>
 			</div>
-		-->
 
 			<div class="row-fluid" style="margin-top:50px">
 				<div class="span6">

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 			<p style="text-align:right;font-size:12px">Realisiert von <a href="https://www.opendatacity.de/">OpenDataCity</a>. Anwendung steht unter <a rel="license" href="http://creativecommons.org/licenses/by/3.0/de/">CC-BY 3.0</a>.</p>
 			
 			<div class="alert alert-info" style="text-align: center">				
-				<a href="https://opendatacity.github.io/prism/" style="color:#08c !important"><b>Außerdem:</b> Wie beim Surfen unsere Daten über das Ausland geleitet werden, zeigen wir hier.</a>
+				<a href="https://opendatacity.github.io/prism/index.de.html" style="color:#08c !important"><b>Außerdem:</b> Wie beim Surfen unsere Daten über das Ausland geleitet werden, zeigen wir hier.</a>
 			</div>
 
 			<div class="row-fluid" style="margin-top:50px">


### PR DESCRIPTION
This just made it's round on Mastodon, which allowed to spot some links being off.